### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-:warning: **SignalFx Smart Agent is deprecated. For details, see the [Deprecation Notice](https://github.com/signalfx/signalfx-agent/blob/main/docs/smartagent-deprecation-notice.md)** :warning:
+> # :warning: End of Support (EoS) Notice
+> **The Heroku SignalFx Collector and SignalFx Smart Agent have reached End of Support.**
+>
+> The [Splunk Distribution of OpenTelemetry Collector for Heroku](https://docs.splunk.com/observability/gdi/monitors-cloud/heroku.html#heroku) is the successor. 
 
 # Heroku SignalFx Collector
 


### PR DESCRIPTION
Adding End of Support notice for Heroku SignalFx Collector (buildpack for SignalFx Smart Agent) since SignalFx Smart Agent https://github.com/signalfx/signalfx-agent reached End of Support on June 30th, 2023.